### PR TITLE
#11 Add eventsObserved support for CEC and CEG event generation

### DIFF
--- a/src/main/java/org/actus/webapp/controllers/EventController.java
+++ b/src/main/java/org/actus/webapp/controllers/EventController.java
@@ -3,6 +3,7 @@ package org.actus.webapp.controllers;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -12,13 +13,19 @@ import org.actus.attributes.ContractModel;
 import org.actus.attributes.ContractModelProvider;
 import org.actus.contracts.ContractType;
 import org.actus.events.ContractEvent;
+import org.actus.events.EventFactory;
 import org.actus.externals.RiskFactorModelProvider;
+import org.actus.functions.csh.STF_AD_CSH;
+import org.actus.functions.pam.POF_AD_PAM;
 import org.actus.states.StateSpace;
+import org.actus.types.ContractTypeEnum;
+import org.actus.types.EventType;
 import org.actus.webapp.models.BatchInputData;
 import org.actus.webapp.models.Event;
 import org.actus.webapp.models.EventStream;
 import org.actus.webapp.models.InputData;
 import org.actus.webapp.models.ObservedData;
+import org.actus.webapp.models.ObservedEvent;
 import org.actus.webapp.utils.TimeSeries;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,11 +33,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 @RestController
 public class EventController {
 
+    private final ObjectMapper objectMapper;
+
+    public EventController(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
     class MarketModel implements RiskFactorModelProvider {
         HashMap<String,TimeSeries<LocalDateTime,Double>> multiSeries = new HashMap<String,TimeSeries<LocalDateTime,Double>>();
+        Set<ContractEvent> eventsObserved = new LinkedHashSet<>();
         
         public Set<String> keys() {
             return multiSeries.keySet();
@@ -44,6 +60,15 @@ public class EventController {
                 ContractModelProvider terms, boolean isMarket) {
             return multiSeries.get(id).getValueFor(time,1);
         }
+
+        public void addEventsObserved(List<ContractEvent> events) {
+            eventsObserved.addAll(events);
+        }
+
+        // CEC and CEG consume externally observed contract events through this core extension point.
+        public Set<ContractEvent> events(ContractModelProvider model) {
+            return eventsObserved;
+        }
     }
 
     // String -> ArrayList<ContractEvent>
@@ -54,9 +79,10 @@ public class EventController {
         // extract contract terms from body
         ContractModel terms = ContractModel.parse(json.getContract());
         List<ObservedData> riskFactorData = json.getRiskFactors();
+        List<ObservedEvent> eventsObserved = json.getEventsObserved();
 
         // create risk factor observer
-        RiskFactorModelProvider observer = createObserver(riskFactorData);
+        RiskFactorModelProvider observer = createObserver(riskFactorData, eventsObserved, terms);
 
         // compute and return events
         return computeEvents(terms, observer);
@@ -72,9 +98,7 @@ public class EventController {
         // extract body parameters
         List<Map<String, Object>> contractData = json.getContracts();
         List<ObservedData> riskFactorData = json.getRiskFactors();
-
-        // create risk factor observer
-        RiskFactorModelProvider observer = createObserver(riskFactorData);
+        List<ObservedEvent> eventsObserved = json.getEventsObserved();
 
         ArrayList<EventStream> output = new ArrayList<>();
         contractData.forEach(entry -> {
@@ -89,6 +113,7 @@ public class EventController {
             }
             // compute contract events
             try {
+                RiskFactorModelProvider observer = createObserver(riskFactorData, eventsObserved, terms);
                 output.add(new EventStream(contractID, "Success", "", computeEvents(terms, observer)));
             }catch(Exception e){
                 output.add(new EventStream(contractID, "Failure", e.toString(), new ArrayList<Event>()));
@@ -97,10 +122,10 @@ public class EventController {
         return output;
     }
 
-    private RiskFactorModelProvider createObserver(List<ObservedData> json) {
+    private RiskFactorModelProvider createObserver(List<ObservedData> riskFactorData, List<ObservedEvent> eventsObserved, ContractModelProvider terms) {
         MarketModel observer = new MarketModel();
 
-        json.forEach(entry -> {
+        riskFactorData.forEach(entry -> {
             String symbol = entry.getMarketObjectCode();
             Double base = entry.getBase();
             LocalDateTime[] times = entry.getData().stream().map(obs -> LocalDateTime.parse(obs.getTime())).toArray(LocalDateTime[]::new);
@@ -111,7 +136,37 @@ public class EventController {
             observer.add(symbol,series);
         });
 
+        // eventsObserved is part of the CEC/CEG trigger path only; other contract types remain unaffected.
+        if(isCreditEnhancement(terms) && eventsObserved != null && !eventsObserved.isEmpty()) {
+            observer.addEventsObserved(readObservedEvents(eventsObserved, terms));
+        }
+
         return observer;
+    }
+
+    private boolean isCreditEnhancement(ContractModelProvider terms) {
+        ContractTypeEnum contractType = terms.getAs("contractType");
+        return contractType == ContractTypeEnum.CEC || contractType == ContractTypeEnum.CEG;
+    }
+
+    private List<ContractEvent> readObservedEvents(List<ObservedEvent> eventsObserved, ContractModelProvider terms) {
+        return eventsObserved.stream().map(e -> {
+        	// Match actus-core fixture handling; these functions are placeholders required to construct ContractEvent.
+            ContractEvent event = EventFactory.createEvent(
+                    LocalDateTime.parse(e.getTime()),
+                    EventType.valueOf(e.getType()),
+                    terms.getAs("currency"),
+                    new POF_AD_PAM(),
+                    new STF_AD_CSH(),
+                    e.getContractId()
+            );
+            event.setStates(readStateSpace(e.getStates()));
+            return event;
+        }).collect(Collectors.toList());
+    }
+
+    private StateSpace readStateSpace(Map<String,Object> input) {
+        return input == null ? new StateSpace() : objectMapper.convertValue(input, StateSpace.class);
     }
 
     private List<Event> computeEvents(ContractModel model, RiskFactorModelProvider observer) {

--- a/src/main/java/org/actus/webapp/models/BatchInputData.java
+++ b/src/main/java/org/actus/webapp/models/BatchInputData.java
@@ -7,13 +7,15 @@ public class BatchInputData {
 
     private List<Map<String,Object>> contracts;
     private List<ObservedData> riskFactors;
+    private List<ObservedEvent> eventsObserved;
 
     public BatchInputData() {
     }
 
-    public BatchInputData(List<Map<String,Object>> contracts, List<ObservedData> riskFactors) {
+    public BatchInputData(List<Map<String,Object>> contracts, List<ObservedData> riskFactors, List<ObservedEvent> eventsObserved) {
         this.contracts = contracts;
         this.riskFactors = riskFactors;
+        this.eventsObserved = eventsObserved;
     }
 
     public List<Map<String,Object>> getContracts() {
@@ -32,11 +34,20 @@ public class BatchInputData {
         this.riskFactors = riskFactors;
     }
 
+    public List<ObservedEvent> getEventsObserved() {
+        return eventsObserved;
+    }
+
+    public void setEventsObserved(List<ObservedEvent> eventsObserved) {
+        this.eventsObserved = eventsObserved;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("ActusData{");
         sb.append("contracts='").append(contracts).append('\'');
         sb.append(", riskFactors='").append(riskFactors).append('\'');
+        sb.append(", eventsObserved='").append(eventsObserved).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/org/actus/webapp/models/InputData.java
+++ b/src/main/java/org/actus/webapp/models/InputData.java
@@ -7,13 +7,15 @@ public class InputData {
 
     private Map<String,Object> contract;
     private List<ObservedData> riskFactors;
+    private List<ObservedEvent> eventsObserved;
 
     public InputData() {
     }
 
-    public InputData(Map<String,Object> contract, List<ObservedData> riskFactors) {
+    public InputData(Map<String,Object> contract, List<ObservedData> riskFactors, List<ObservedEvent> eventsObserved) {
         this.contract = contract;
         this.riskFactors = riskFactors;
+        this.eventsObserved = eventsObserved;
     }
 
     public Map<String,Object> getContract() {
@@ -32,11 +34,20 @@ public class InputData {
         this.riskFactors = riskFactors;
     }
 
+    public List<ObservedEvent> getEventsObserved() {
+        return eventsObserved;
+    }
+
+    public void setEventsObserved(List<ObservedEvent> eventsObserved) {
+        this.eventsObserved = eventsObserved;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("InputData{");
         sb.append("contract='").append(contract).append('\'');
         sb.append(", riskFactors='").append(riskFactors).append('\'');
+        sb.append(", eventsObserved='").append(eventsObserved).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/org/actus/webapp/models/ObservedEvent.java
+++ b/src/main/java/org/actus/webapp/models/ObservedEvent.java
@@ -1,0 +1,75 @@
+package org.actus.webapp.models;
+
+import java.util.Map;
+
+public class ObservedEvent {
+
+    private String time;
+    private String type;
+    private Double value;
+    private String contractId;
+    private Map<String,Object> states;
+
+    public ObservedEvent() {
+    }
+
+    public ObservedEvent(String time, String type, Double value, String contractId, Map<String,Object> states) {
+        this.time = time;
+        this.type = type;
+        this.value = value;
+        this.contractId = contractId;
+        this.states = states;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public void setTime(String time) {
+        this.time = time;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Double getValue() {
+        return value;
+    }
+
+    public void setValue(Double value) {
+        this.value = value;
+    }
+
+    public String getContractId() {
+        return contractId;
+    }
+
+    public void setContractId(String contractId) {
+        this.contractId = contractId;
+    }
+
+    public Map<String,Object> getStates() {
+        return states;
+    }
+
+    public void setStates(Map<String,Object> states) {
+        this.states = states;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ObservedEvent{");
+        sb.append("time='").append(time).append('\'');
+        sb.append(", type='").append(type).append('\'');
+        sb.append(", value='").append(value).append('\'');
+        sb.append(", contractId='").append(contractId).append('\'');
+        sb.append(", states='").append(states).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary

This PR extends the existing `/events` and `/eventsBatch` request handling to support optional `eventsObserved` data for CEC and CEG contracts.

CEC and CEG schedules can depend on externally observed events on referenced contracts, such as a covered contract credit event (`CE`) with `contractPerformance = DF`. `actus-core` already supports this through `RiskFactorModelProvider.events(...)`; this PR wires `actus-service` to pass that data through in the same shape used by core fixtures.

No new endpoint is added.

## Changes

- Added an optional `eventsObserved` field to:
  - `InputData`
  - `BatchInputData`

- Added `ObservedEvent` DTO with:
  - `time`
  - `type`
  - `value`
  - `contractId`
  - `states`

- Extended the existing `MarketModel` risk factor provider to expose observed contract events through `RiskFactorModelProvider.events(...)`.

- Converted incoming observed events into core `ContractEvent` instances using the same fixture-handling pattern used in `actus-core`.

- Converted `eventsObserved.states` into core `StateSpace` using Jackson `ObjectMapper`.

- Applied `eventsObserved` only when the processed contract type is:
  - `CEC`
  - `CEG`

## Behavior

For CEC/CEG contracts, `eventsObserved` can now trigger externally driven `XD` and `STD` events when the observed event matches the referenced covered contract and covered credit event type.

For all other contract types, `eventsObserved` is not applied.

CEC/CEG requests without `eventsObserved`, or with an empty `eventsObserved` array, continue to behave as before.

## Backward Compatibility
This change is backward compatible:
- `eventsObserved` is optional.
- Existing request shapes continue to work.
- No response format changes were made.
- Non-CEC/CEG contract types are unaffected.
- Existing `riskFactors` handling is unchanged.

## Testing
- Verified manually through `/events` with a `collateral02`-style CEC payload.
- Confirmed the trigger path returns expected `XD` and `STD` events.
- Confirmed Java compilation passes:
  - `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew compileJava`